### PR TITLE
Copy email instead of mailto + Pill styling change

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -84,7 +84,7 @@ const Footer: React.FC = () => {
         ) : (
           <div className='relative'>
             {ClipboardCheckedIcon}{' '}
-            <div className='flex flex-row align-middle justify-center absolute z-10 top-0 bottom-0 left-9 whitespace-nowrap px-3 py-2 rounded-lg bg-gray-800 text-gray-200 dark:bg-gray-300 dark:text-gray-800 dark:font-semibold'>
+            <div className='flex flex-row align-middle justify-center absolute z-10 top-0 bottom-0 left-9 whitespace-nowrap px-3 py-2 rounded-lg bg-gray-600 text-gray-200 dark:bg-gray-300 dark:text-gray-800 dark:font-semibold'>
               <span className="-my-2">Email copied!</span>
             </div>
           </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import { DateTime } from 'luxon';
+import { useState } from 'react';
 
 const LinkedInLogo = (
   <svg
@@ -34,7 +35,29 @@ const MailIcon = (
   </svg>
 );
 
+const ClipboardCheckedIcon = (
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    viewBox='0 0 24 24'
+    fill='currentColor'
+    className='w-6 h-6 fill-gray-600 dark:fill-gray-200'
+  >
+    <path
+      fillRule='evenodd'
+      d='M7.502 6h7.128A3.375 3.375 0 0118 9.375v9.375a3 3 0 003-3V6.108c0-1.505-1.125-2.811-2.664-2.94a48.972 48.972 0 00-.673-.05A3 3 0 0015 1.5h-1.5a3 3 0 00-2.663 1.618c-.225.015-.45.032-.673.05C8.662 3.295 7.554 4.542 7.502 6zM13.5 3A1.5 1.5 0 0012 4.5h4.5A1.5 1.5 0 0015 3h-1.5z'
+      clipRule='evenodd'
+    />
+    <path
+      fillRule='evenodd'
+      d='M3 9.375C3 8.339 3.84 7.5 4.875 7.5h9.75c1.036 0 1.875.84 1.875 1.875v11.25c0 1.035-.84 1.875-1.875 1.875h-9.75A1.875 1.875 0 013 20.625V9.375zm9.586 4.594a.75.75 0 00-1.172-.938l-2.476 3.096-.908-.907a.75.75 0 00-1.06 1.06l1.5 1.5a.75.75 0 001.116-.062l3-3.75z'
+      clipRule='evenodd'
+    />
+  </svg>
+);
+
 const Footer: React.FC = () => {
+  const [isClipboardVisible, setIsClipboardVisible] = useState(false);
+
   return (
     <footer className='flex flex-col'>
       <div className='flex justify-center space-x-4 pb-8'>
@@ -47,14 +70,20 @@ const Footer: React.FC = () => {
         <a aria-label='GitHub logo' href='https://github.com/kevinqdam'>
           {GithubIcon}
         </a>
-        <a
-          aria-label='Mail icon'
-          href='mailto:me@kevinqdam.com'
-          target='_blank'
-          rel='noreferrer noopener'
-        >
-          {MailIcon}
-        </a>
+        {!isClipboardVisible ? (
+          <button
+            aria-label='Mail icon'
+            onClick={async () => {
+              await navigator.clipboard.writeText('me@kevinqdam.com');
+              setIsClipboardVisible(true);
+              setTimeout(() => setIsClipboardVisible(false), 2_000);
+            }}
+          >
+            {MailIcon}
+          </button>
+        ) : (
+          <div>{ClipboardCheckedIcon}</div>
+        )}
       </div>
       <span className='text-center block pb-8'>
         © {DateTime.now().year} Kevin Q. Dam

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -84,8 +84,8 @@ const Footer: React.FC = () => {
         ) : (
           <div className='relative'>
             {ClipboardCheckedIcon}{' '}
-            <div className='flex flex-row align-middle justify-center absolute z-10 top-0 bottom-0 left-9 whitespace-nowrap px-3 py-2 rounded-lg bg-gray-600 text-gray-200 dark:bg-gray-300 dark:text-gray-800 dark:font-semibold'>
-              <span className="-my-2">Email copied!</span>
+            <div className='flex flex-row align-middle justify-center absolute z-10 -top-7 -left-9 sm:top-0 sm:left-9 whitespace-nowrap overflow-hidden over px-3 py-2 rounded-lg bg-gray-600 text-gray-200 dark:bg-gray-300 dark:text-gray-800 dark:font-regular transition-all animate-fade-out-up opacity-0'>
+              <span className='-my-2 overflow-hidden'>Email copied!</span>
             </div>
           </div>
         )}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -82,7 +82,12 @@ const Footer: React.FC = () => {
             {MailIcon}
           </button>
         ) : (
-          <div>{ClipboardCheckedIcon}</div>
+          <div className='relative'>
+            {ClipboardCheckedIcon}{' '}
+            <div className='flex flex-row align-middle justify-center absolute z-10 top-0 bottom-0 left-9 whitespace-nowrap px-3 py-2 rounded-lg bg-gray-800 text-gray-200 dark:bg-gray-300 dark:text-gray-800 dark:font-semibold'>
+              <span className="-my-2">Email copied!</span>
+            </div>
+          </div>
         )}
       </div>
       <span className='text-center block pb-8'>

--- a/src/components/Pills.tsx
+++ b/src/components/Pills.tsx
@@ -11,15 +11,15 @@ type PillsProps = {
 };
 
 const Pills: React.FC<PillsProps> = ({ pills }) => (
-  <ul className='items-top flex flex-row gap-2 flex-wrap'>
+  <ul className='flex flex-row gap-2 flex-wrap'>
     {pills.map(({ text, href, invertColor }, index) => (
       <div key={`${text}-${index}`}>
         <li
           className={cn(
             'rounded px-2.5 py-0.5 font-semibold',
             invertColor
-              ? 'bg-pink-800 text-pink-100 dark:bg-teal-800 dark:text-teal-200'
-              : 'bg-pink-100 text-pink-800 dark:bg-teal-200 dark:text-teal-800'
+              ? 'outline bg-pink-800 text-pink-100 dark:bg-teal-800 dark:text-teal-200'
+              : 'outline bg-pink-100 text-pink-800 dark:bg-teal-200 dark:text-teal-800'
           )}
         >
           {href ? (

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -48,7 +48,7 @@ const { title } = Astro.props;
           @apply inline-block px-2 rounded-lg bg-slate-200 dark:bg-gray-900 m-0.5;
         }
         a > code:not([data-theme]) {
-          @apply underline
+          @apply underline;
         }
       }
     </style></head
@@ -66,7 +66,7 @@ const { title } = Astro.props;
             <slot />
           </main>
           <hr class='my-8 h-px border-0 bg-gray-400 dark:bg-gray-500' />
-          <Footer />
+          <Footer client:load />
         </div>
       </div>
     </div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -22,6 +22,21 @@ module.exports = {
         xl: { css: disabledCss },
         '2xl': { css: disabledCss },
       },
+      keyframes: {
+        'fade-out-up-keyframe': {
+          '0%': {
+            opacity: '1',
+            transform: 'translateY(0)',
+          },
+          '100%': {
+            opacity: '0',
+            transform: 'translateY(-30px)',
+          },
+        },
+      },
+      animation: {
+        'fade-out-up': 'fade-out-up-keyframe 1.125s ease-in',
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
### Summary
- Copy the email address instead of opening the user's default mail client when clicking the mail icon in the footer
- Show a clipboard icon when clicked
- The tooltip translates upwards and fades out
- Remove a CSS class that was unused and not recognized by Tailwind
- Add an outline to Pills