### PR TITLE
Use ring instead of outline for pills to be outlined round on mobile

### DIFF
--- a/src/components/Pills.tsx
+++ b/src/components/Pills.tsx
@@ -11,15 +11,15 @@ type PillsProps = {
 };
 
 const Pills: React.FC<PillsProps> = ({ pills }) => (
-  <ul className='flex flex-row gap-2 flex-wrap'>
+  <ul className='flex flex-row gap-3 flex-wrap'>
     {pills.map(({ text, href, invertColor }, index) => (
       <div key={`${text}-${index}`}>
         <li
           className={cn(
-            'rounded px-2.5 py-0.5 font-semibold',
+            'ring rounded px-2.5 py-0.5 font-semibold',
             invertColor
-              ? 'outline bg-pink-800 text-pink-100 dark:bg-teal-800 dark:text-teal-200'
-              : 'outline bg-pink-100 text-pink-800 dark:bg-teal-200 dark:text-teal-800'
+              ? 'ring-pink-800 bg-pink-800 text-pink-100 dark:ring-teal-800 dark:bg-teal-800 dark:text-teal-200'
+              : 'ring-pink-800 bg-pink-100 text-pink-800 dark:ring-teal-800 dark:bg-teal-200 dark:text-teal-800'
           )}
         >
           {href ? (


### PR DESCRIPTION
On Safari and mobile, the Tailwind `outline` utility class will be square instead of round for `Pill`s. Use `ring` instead.
- Relevant [GitHub discussion](https://github.com/tailwindlabs/tailwindcss/discussions/7649)